### PR TITLE
Add support for GNOME Shell 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ AppKeys Gnome Shell Extension
 Adds Super+NUM shortcuts for activating applications from dash.
 Extension can be installed from https://extensions.gnome.org/extension/413/dash-hotkeys/
 
-Works with latest Gnome Shell versions 3.6/3.8/3.10/3.12
+Works with latest Gnome Shell versions: 3.6, 3.8, 3.10, 3.12, 3.14.

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
     "3.6", 
     "3.8", 
     "3.10", 
-    "3.12"
+    "3.12",
+    "3.14"
   ], 
   "url": "https://github.com/franziskuskiefer/app-keys-gnome-shell-extension", 
   "uuid": "unitylike-hotkey@webgyerek.net", 


### PR DESCRIPTION
Looks like the extension works well too in version 3.14

Tested with gnome-shell 3.14.0-1, in Debian jessie (testing).
