### PR TITLE
Allow AppKeys key bindings in Overview mode.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -68,7 +68,7 @@ AppKeys.prototype = {
 
 	_addKeybindings: function(name, handler) {
 		if (Main.wm.addKeybinding)
-        	Main.wm.addKeybinding(name, this.settings, Meta.KeyBindingFlags.NONE, Shell.KeyBindingMode.NORMAL, handler);
+        	Main.wm.addKeybinding(name, this.settings, Meta.KeyBindingFlags.NONE, Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.OVERVIEW, handler);
 		else
 		   global.display.add_keybinding(name, this.settings, Meta.KeyBindingFlags.NONE, handler);
 	},


### PR DESCRIPTION
The proposed modification allows AppKeys to work in Overview mode. This capability was also mentioned in Pull request [#11](https://github.com/franziskuskiefer/app-keys-gnome-shell-extension/pull/11#issuecomment-59417085).

The other option would be to add that 'capability' in Preferences -- I'm not actually sure if anyone would want the functionality disabled in Overview?

It works with Gnome 3.10, 3.12, 3.14.
