### PR TITLE
Gnome 3.16 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ AppKeys Gnome Shell Extension
 Adds Super+NUM shortcuts for activating applications from dash.
 Extension can be installed from https://extensions.gnome.org/extension/413/dash-hotkeys/
 
-Works with latest Gnome Shell versions: 3.6, 3.8, 3.10, 3.12, 3.14.
+Works with latest Gnome Shell version: 3.16

--- a/extension.js
+++ b/extension.js
@@ -73,7 +73,7 @@ AppKeys.prototype = {
 
 	_addKeybindings: function(name, handler) {
 		if (Main.wm.addKeybinding)
-		   Main.wm.addKeybinding(name, this.settings, Meta.KeyBindingFlags.NONE, Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.OVERVIEW, handler);
+		   Main.wm.addKeybinding(name, this.settings, Meta.KeyBindingFlags.NONE, Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW, handler);
 		else
 		   global.display.add_keybinding(name, this.settings, Meta.KeyBindingFlags.NONE, handler);
 	},

--- a/metadata.json
+++ b/metadata.json
@@ -4,14 +4,9 @@
   "name": "AppKeys", 
   "settings-schema": "org.gnome.shell.extensions.app-keys", 
   "shell-version": [
-    "3.4", 
-    "3.6", 
-    "3.8", 
-    "3.10", 
-    "3.12",
-    "3.14"
+    "3.16"
   ], 
   "url": "https://github.com/franziskuskiefer/app-keys-gnome-shell-extension", 
   "uuid": "unitylike-hotkey@webgyerek.net", 
-  "version": 9
+  "version": 10
 }


### PR DESCRIPTION
There has been a small API update in GNOME 3.16, KeyBindingMode is now called ActionMode.
I think it's the nicest way to handle things in two seperate branches, mostly because I don't know how to find out the version of the Shell in which we're currently running.
So this should actually be merged in to a new branch.