### PR TITLE
Only cycle windows on active workspace

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -51,20 +51,20 @@ AppKeys.prototype = {
 		            return actor.child._delegate.app;
 		        });
 
-
+            let windows = apps[id].get_windows();
 		    if(typeof(apps[id]) !== 'undefined') { // This is just to ignore problems when there is no such app (yet).
-		        if (options.newwindow || apps[id].get_windows().length == 0)
+		        if (options.newwindow || windows.length == 0)
 		            apps[id].open_new_window(-1);
 		        else {
 		            if (options.cycleWindows) {
-		                if (apps[id].get_windows()[0].has_focus()) {
-		                    apps[id].get_windows()[apps[id].get_windows().length - 1].activate(0);
+		                if (windows[0].has_focus()) {
+		                    windows[windows.length - 1].activate(0);
 		                } else {
-		                    apps[id].get_windows()[0].activate(0);
+		                    windows[0].activate(0);
 		                }
 		            } else {
 		                if(options.raiseFirst) // raise only "first" (last used) window of the app
-		                    apps[id].get_windows()[0].activate(0);
+		                    windows[0].activate(0);
 		                else
 		                    apps[id].activate();
 		            }

--- a/extension.js
+++ b/extension.js
@@ -52,6 +52,12 @@ AppKeys.prototype = {
 		        });
 
             let windows = apps[id].get_windows();
+            if (options.onlyActiveWorkspace) {
+                let activeWorkspace = global.screen.get_active_workspace();
+                windows = windows.filter(function (w) {
+                    return w.get_workspace() == activeWorkspace;
+                });
+            }
 		    if(typeof(apps[id]) !== 'undefined') { // This is just to ignore problems when there is no such app (yet).
 		        if (options.newwindow || windows.length == 0)
 		            apps[id].open_new_window(-1);
@@ -111,16 +117,16 @@ AppKeys.prototype = {
 			var j = i-1;
 			if (i == 0) j = 9;
 			if (enableNUM)
-				this._addKeybindings('app-key'+i, this.clickClosure(j, {closeoverview: close_overview, raiseFirst: raise_first, cycleWindows: cycle_windows}));
+				this._addKeybindings('app-key'+i, this.clickClosure(j, {closeoverview: close_overview, raiseFirst: raise_first, cycleWindows: cycle_windows, onlyActiveWorkspace: true}));
 
 			if (enableNW)
-				this._addKeybindings('app-key-shift'+i, this.clickClosure(j, {newwindow: true, closeoverview: close_overview, cycleWindows: cycle_windows}));
+				this._addKeybindings('app-key-shift'+i, this.clickClosure(j, {newwindow: true, closeoverview: close_overview, cycleWindows: cycle_windows, onlyActiveWorkspace: true}));
 
 			if (enableNKP)
-				this._addKeybindings('app-key-shift-kp'+i, this.clickClosure(j, {newwindow: true, closeoverview: close_overview, cycleWindows: cycle_windows}));
+				this._addKeybindings('app-key-shift-kp'+i, this.clickClosure(j, {newwindow: true, closeoverview: close_overview, cycleWindows: cycle_windows, onlyActiveWorkspace: true}));
 
 			if (enableKP)
-				this._addKeybindings('app-key-kp'+i, this.clickClosure(j, {closeoverview: close_overview, raiseFirst: raise_first, cycleWindows: cycle_windows}));
+				this._addKeybindings('app-key-kp'+i, this.clickClosure(j, {closeoverview: close_overview, raiseFirst: raise_first, cycleWindows: cycle_windows, onlyActiveWorkspace: true}));
 		}
 	},
 

--- a/extension.js
+++ b/extension.js
@@ -25,7 +25,7 @@ AppKeys.prototype = {
 
 	init: function() {
 		this.settings = Convenience.getSettings();
-	
+
 		this.settings.connect('changed::' + config.SETTINGS_USE_KEYPAD, Lang.bind(this, this.toggleKeys));
 		this.settings.connect('changed::' + config.SETTINGS_USE_NUMS, Lang.bind(this, this.toggleKeys));
 		this.settings.connect('changed::' + config.SETTINGS_USE_NW, Lang.bind(this, this.toggleKeys));
@@ -69,7 +69,7 @@ AppKeys.prototype = {
 		                    apps[id].activate();
 		            }
 		        }
-		        
+
 		    // close overview after selecting application
 				if(options.closeoverview)
 			        Main.overview.hide();
@@ -90,7 +90,7 @@ AppKeys.prototype = {
 		} else
 		   global.display.add_keybinding(name, this.settings, Meta.KeyBindingFlags.NONE, handler);
 	},
-	
+
 	_removeKeybindings: function(name) {
 		if (Main.wm.removeKeybinding)
         	Main.wm.removeKeybinding(name);
@@ -106,13 +106,13 @@ AppKeys.prototype = {
 		let close_overview = this.settings.get_boolean(config.SETTINGS_CLOSE_OVERVIEW);
 		let raise_first = this.settings.get_boolean(config.SETTINGS_RAISE_FIRST);
 		let cycle_windows = this.settings.get_boolean(config.SETTINGS_CYCLE_WINDOWS);
-	
+
 		for(var i=0; i<10; i++) {
 			var j = i-1;
 			if (i == 0) j = 9;
 			if (enableNUM)
 				this._addKeybindings('app-key'+i, this.clickClosure(j, {closeoverview: close_overview, raiseFirst: raise_first, cycleWindows: cycle_windows}));
-	
+
 			if (enableNW)
 				this._addKeybindings('app-key-shift'+i, this.clickClosure(j, {newwindow: true, closeoverview: close_overview, cycleWindows: cycle_windows}));
 
@@ -123,7 +123,7 @@ AppKeys.prototype = {
 				this._addKeybindings('app-key-kp'+i, this.clickClosure(j, {closeoverview: close_overview, raiseFirst: raise_first, cycleWindows: cycle_windows}));
 		}
 	},
-	
+
 	disable: function(){
 		for(var i=0; i<10; i++) {
 		    this._removeKeybindings('app-key'+i);


### PR DESCRIPTION
Hi,

this pull request makes the "Cycle Windows" option only cycle through windows on the active workspace (currently all windows on all workspaces are being cycled). I split the the PR into three commits:

1. Just removes some unnecessary whitespace
2. Refactors the windows for the app into a variable
3. Cycle through the windows only on the active workspace

I tried to create an option for the cycling through the windows, but I didn't manage. I must have done something wrong when using the `glib-compile-schemas` command :confused: