### PR TITLE
Fix typo: windows -> workspace

### DIFF
--- a/schemas/org.gnome.shell.extensions.app-keys.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.app-keys.gschema.xml
@@ -327,7 +327,7 @@
       <default>true</default>
       <summary>Cycle Windows on Active Workspace</summary>
       <description>
-        Do you want to cycle through windows using chosen keybindings on active windows only?
+        Do you want to cycle through windows using chosen keybindings on active workspace only?
       </description>
     </key>
     <key name="raise-first" type="b">


### PR DESCRIPTION
I think you meant `"workspace"` instead of `"windows"`. Feel free to discard this PR if I'm mistaken!