### PR TITLE
Fixes bug 20: unresposive appkeys with Dash-to-dock

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -5,8 +5,6 @@ const Lang = imports.lang;
 
 // Import shell
 const Shell = imports.gi.Shell;
-// Import Dash also
-const Dash = Main.overview._dash;
 
 // Import the convenience.js (Used for loading settings schemas)
 const Self = imports.misc.extensionUtils.getCurrentExtension();
@@ -42,6 +40,8 @@ AppKeys.prototype = {
     return function() {
       // Get the current actors from Dash, and get apps from the actors
       // This part is copied from the dash source (/usr/share/gnomes-shell/js/ui/dash.js)
+      // Import Dash
+      const Dash = Main.overview._dash;
       let children = Dash._box.get_children().filter(function(actor) {
         return actor.child &&
                actor.child._delegate &&

--- a/extension.js
+++ b/extension.js
@@ -51,7 +51,9 @@ AppKeys.prototype = {
         return actor.child._delegate.app;
       });
 
-      let windows = apps[id].get_windows();
+      let windows = apps[id].get_windows().filter(function(w) {
+        return !w.skip_taskbar;
+      });
       if (options.onlyActiveWorkspace) {
         let activeWorkspace = global.screen.get_active_workspace();
         windows = windows.filter(function(w) {


### PR DESCRIPTION
This commit fixes the issue where the app keys are unresponsive after a screen lock.

The only thing done here is a re-declaration of the "Dash" where it is needed, instead of being a global const.