### PR TITLE
Implement a smart 'Cycle windows' function

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,6 @@
 //Import the Main and Meta object
 const Main = imports.ui.main;
+const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
 const Lang = imports.lang;
 
@@ -13,6 +14,10 @@ const Convenience = Self.imports.convenience;
 // Import config
 const config = Self.imports.config;
 
+let recentlyClickedAppLoopId = 0;
+let recentlyClickedApp = null;
+let recentlyClickedAppWindows = null;
+let recentlyClickedAppIndex = 0;
 function AppKeys() {
   this.init();
 }
@@ -66,7 +71,7 @@ AppKeys.prototype = {
         else {
           if (options.cycleWindows) {
             if (windows[0].has_focus()) {
-              Main.activateWindow(windows[windows.length - 1]);
+              cycleThroughWindows(apps[id], windows);
             } else {
               Main.activateWindow(windows[0]);
             }
@@ -146,6 +151,42 @@ AppKeys.prototype = {
   }
 
 };
+
+function cycleThroughWindows(app, app_windows) {
+    // Store for a little amount of time last clicked app and its windows
+    // since the order changes upon window interaction
+    let MEMORY_TIME=3000;
+
+    if (recentlyClickedAppLoopId > 0)
+        Mainloop.source_remove(recentlyClickedAppLoopId);
+    recentlyClickedAppLoopId = Mainloop.timeout_add(MEMORY_TIME, resetRecentlyClickedApp);
+
+    // If there isn't already a list of windows for the current app,
+    // or the stored list is outdated, use the current windows list.
+    if (!recentlyClickedApp ||
+        recentlyClickedApp.get_id() != app.get_id() ||
+        recentlyClickedAppWindows.length != app_windows.length) {
+        recentlyClickedApp = app;
+        recentlyClickedAppWindows = app_windows;
+        recentlyClickedAppIndex = 0;
+    }
+
+    recentlyClickedAppIndex++;
+    let index = recentlyClickedAppIndex % recentlyClickedAppWindows.length;
+    let window = recentlyClickedAppWindows[index];
+
+    Main.activateWindow(window);
+}
+function resetRecentlyClickedApp() {
+    if (recentlyClickedAppLoopId > 0)
+        Mainloop.source_remove(recentlyClickedAppLoopId);
+    recentlyClickedAppLoopId=0;
+    recentlyClickedApp =null;
+    recentlyClickedAppWindows = null;
+    recentlyClickedAppIndex = 0;
+
+    return false;
+}
 
 let app;
 

--- a/extension.js
+++ b/extension.js
@@ -66,9 +66,9 @@ AppKeys.prototype = {
         else {
           if (options.cycleWindows) {
             if (windows[0].has_focus()) {
-              windows[windows.length - 1].activate(0);
+              Main.activateWindow(windows[windows.length - 1]);
             } else {
-              windows[0].activate(0);
+              Main.activateWindow(windows[0]);
             }
           } else {
             if (options.raiseFirst)  // raise only "first" (last used) window of the app

--- a/extension.js
+++ b/extension.js
@@ -14,10 +14,6 @@ const Convenience = Self.imports.convenience;
 // Import config
 const config = Self.imports.config;
 
-let recentlyClickedAppLoopId = 0;
-let recentlyClickedApp = null;
-let recentlyClickedAppWindows = null;
-let recentlyClickedAppIndex = 0;
 function AppKeys() {
   this.init();
 }
@@ -152,40 +148,47 @@ AppKeys.prototype = {
 
 };
 
+let recentlyClickedAppLoopId = 0;
+let recentlyClickedApp = null;
+let recentlyClickedAppWindows = null;
+let recentlyClickedAppIndex = 0;
+
+// This function was ported straight from Dash-to-Dock
 function cycleThroughWindows(app, app_windows) {
-    // Store for a little amount of time last clicked app and its windows
-    // since the order changes upon window interaction
-    let MEMORY_TIME=3000;
+  // Store for a little amount of time last clicked app and its windows
+  // since the order changes upon window interaction
+  let MEMORY_TIME=3000;
 
-    if (recentlyClickedAppLoopId > 0)
-        Mainloop.source_remove(recentlyClickedAppLoopId);
-    recentlyClickedAppLoopId = Mainloop.timeout_add(MEMORY_TIME, resetRecentlyClickedApp);
+  if (recentlyClickedAppLoopId > 0)
+      Mainloop.source_remove(recentlyClickedAppLoopId);
+  recentlyClickedAppLoopId = Mainloop.timeout_add(MEMORY_TIME, resetRecentlyClickedApp);
 
-    // If there isn't already a list of windows for the current app,
-    // or the stored list is outdated, use the current windows list.
-    if (!recentlyClickedApp ||
-        recentlyClickedApp.get_id() != app.get_id() ||
-        recentlyClickedAppWindows.length != app_windows.length) {
-        recentlyClickedApp = app;
-        recentlyClickedAppWindows = app_windows;
-        recentlyClickedAppIndex = 0;
-    }
-
-    recentlyClickedAppIndex++;
-    let index = recentlyClickedAppIndex % recentlyClickedAppWindows.length;
-    let window = recentlyClickedAppWindows[index];
-
-    Main.activateWindow(window);
-}
-function resetRecentlyClickedApp() {
-    if (recentlyClickedAppLoopId > 0)
-        Mainloop.source_remove(recentlyClickedAppLoopId);
-    recentlyClickedAppLoopId=0;
-    recentlyClickedApp =null;
-    recentlyClickedAppWindows = null;
+  // If there isn't already a list of windows for the current app,
+  // or the stored list is outdated, use the current windows list.
+  if (!recentlyClickedApp ||
+    recentlyClickedApp.get_id() != app.get_id() ||
+    recentlyClickedAppWindows.length != app_windows.length) {
+    recentlyClickedApp = app;
+    recentlyClickedAppWindows = app_windows;
     recentlyClickedAppIndex = 0;
+  }
 
-    return false;
+  recentlyClickedAppIndex++;
+  let index = recentlyClickedAppIndex % recentlyClickedAppWindows.length;
+  let window = recentlyClickedAppWindows[index];
+
+  Main.activateWindow(window);
+}
+
+function resetRecentlyClickedApp() {
+  if (recentlyClickedAppLoopId > 0)
+    Mainloop.source_remove(recentlyClickedAppLoopId);
+  recentlyClickedAppLoopId=0;
+  recentlyClickedApp =null;
+  recentlyClickedAppWindows = null;
+  recentlyClickedAppIndex = 0;
+
+  return false;
 }
 
 let app;


### PR DESCRIPTION
Hi,

This PR is a bit more intrusive that the previous one I proposed. It should take care of issue https://github.com/franziskuskiefer/app-keys-gnome-shell-extension/issues/26.

Feel free to reject this if you don't like too much. But, at least patch 74d1701e214d934b71311a776b65d6f4b474d039 is enough to solve the issue. However, it was pointed out (@bosyi) in that discussion that the cycling behaviour can be a bit annoying as it is.
The test case for that would be to open 3 windows in one workspace, and only 1 window in another workspace, and start cycling.

Patches 7fc54c07ab2758a424309b917bb73a63a282effb and 0f30f6667f40716dba3c54cb0d12bd10ee24931a implement the same cycling as the Dash-to-dock extension.

Cheers