### PR TITLE
Added support for Gnome Shell 3.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ AppKeys Gnome Shell Extension
 Adds Super+NUM shortcuts for activating applications from dash.
 Extension can be installed from https://extensions.gnome.org/extension/413/dash-hotkeys/
 
-Works with latest Gnome Shell versions: 3.8, 3.10, 3.12, 3.14, 3.16, 3.18., 3.20
+Works with latest Gnome Shell versions: 3.8, 3.10, 3.12, 3.14, 3.16, 3.18, 3.20, 3.22.

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
     "3.14",
     "3.16",
     "3.18",
-    "3.20"
+    "3.20",
+    "3.22"
   ], 
   "url": "https://github.com/franziskuskiefer/app-keys-gnome-shell-extension", 
   "uuid": "unitylike-hotkey@webgyerek.net", 


### PR DESCRIPTION
Tested with Gnome Shell 3.22.2 on ArchLinux and it works without any problem.