### PR TITLE
Before removing keybindings, verify if enabled in the settings

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -144,11 +144,17 @@ AppKeys.prototype = {
   },
 
   disable : function() {
+    let enableNUM = this.settings.get_boolean(config.SETTINGS_USE_NUMS);
+    let enableKP = this.settings.get_boolean(config.SETTINGS_USE_KEYPAD);
     for (var i = 0; i < 10; i++) {
-      this._removeKeybindings('app-key' + i);
-      this._removeKeybindings('app-key-shift' + i);
-      this._removeKeybindings('app-key-kp' + i);
-      this._removeKeybindings('app-key-shift-kp' + i);
+      if (enableNUM) {
+        this._removeKeybindings('app-key' + i);
+        this._removeKeybindings('app-key-shift' + i);
+      }
+      if (enableKP) {
+        this._removeKeybindings('app-key-kp' + i);
+        this._removeKeybindings('app-key-shift-kp' + i);
+      }
     }
   }
 


### PR DESCRIPTION
When invoking the disable function, the keybindings are removed even when not added and recent versions of Gnome Shell have started to emit error messages of non-existent keybindings.

Don't know if it's the best approach, anyway I've made a small patch that check in the settings if the keybindings should be removed.