### PR TITLE
Gnome 3.30 compatibility. fixes #43

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -56,7 +56,7 @@ AppKeys.prototype = {
         return !w.skip_taskbar;
       });
       if (options.onlyActiveWorkspace) {
-        let activeWorkspace = global.screen.get_active_workspace();
+        let activeWorkspace = (global.screen || global.workspace_manager).get_active_workspace();
         windows = windows.filter(function(w) {
           return w.get_workspace() == activeWorkspace;
         });


### PR DESCRIPTION
fixes #43

adapt to following commits:
https://gitlab.gnome.org/GNOME/gnome-shell/commit/47ea10b7c976abb1b9ab4f34da87abb1e36855fe
https://gitlab.gnome.org/GNOME/gnome-shell-extensions/commit/6583eae6225039b6b711918eff3a7cd0d03a42ca

This fix should be backward compatible(going back as far as te previous version), but I only tested with 3.30.