### PR TITLE
Improve fix for 3.36 so it keeps working on older OSes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -42,7 +42,7 @@ AppKeys.prototype = {
       // Get the current actors from Dash, and get apps from the actors
       // This part is copied from the dash source (/usr/share/gnomes-shell/js/ui/dash.js)
       // Import Dash
-      const Dash = Main.overview.dash;
+      const Dash = Main.overview.dash || Main.overview._dash;
       let children = Dash._box.get_children().filter(function(actor) {
         return actor.child &&
                actor.child._delegate &&


### PR DESCRIPTION
Debian buster still ships with Gnome 3.30, and the fix for #49 prevents these older shells from working.

This patch tries to use the newer way of importing `Dash` (`Main.overview.dash`), but falls back the old way (`Main.overview._dash`) if the newer name isn't available.